### PR TITLE
EC2 partials cleanup

### DIFF
--- a/blueprints/common/partials/ec2_clientvpnroute.hbs
+++ b/blueprints/common/partials/ec2_clientvpnroute.hbs
@@ -10,7 +10,7 @@
 
   https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-clientvpnroute.html
  --}}
-"ec2clntvpnauthrule{{sanitize this.Name ''}}": {
+"ec2clntvpnrule{{sanitize this.Name ''}}": {
   "Type": "AWS::EC2::ClientVpnRoute",
   "Properties": {
     "ClientVpnEndpointId":

--- a/blueprints/common/partials/elasticloadbalancingv2_loadbalancer.hbs
+++ b/blueprints/common/partials/elasticloadbalancingv2_loadbalancer.hbs
@@ -9,7 +9,7 @@
   "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
   {{#if this.DependsOn}}"DependsOn": "{{this.DependsOn}}",{{/if}}
   "Properties": {
-    "Name": "{{this.Name}}-{{@root.EnvName}}",
+    "Name": "{{this.Name}}",
     "Scheme": "{{this.Scheme}}",
     {{#if this.SubnetMappings}}
       "SubnetMappings": [

--- a/blueprints/common/partials/elasticloadbalancingv2_targetgroup.hbs
+++ b/blueprints/common/partials/elasticloadbalancingv2_targetgroup.hbs
@@ -6,7 +6,7 @@
 "elbv2tg{{sanitize this.Name ''}}": {
   "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
   "Properties": {
-    "Name": "{{this.Name}}-{{@root.EnvName}}",
+    "Name": "{{this.Name}}",
     "Port": {{this.Port}},
     "Protocol": "{{uppercase this.Protocol}}",
     {{#if this.HealthCheckIntervalSeconds}}"HealthCheckIntervalSeconds": {{this.HealthCheckIntervalSeconds}},{{/if}}


### PR DESCRIPTION
This PR corrects a problem with the ClientVPN route and removes the "EnvName" from the ELBv2 load balancer partials.