### PR TITLE
Allow automatic ACM verification

### DIFF
--- a/blueprints/common/partials/certificatemanager_certificate.hbs
+++ b/blueprints/common/partials/certificatemanager_certificate.hbs
@@ -7,8 +7,15 @@
   "Type": "AWS::CertificateManager::Certificate",
   "Properties": {
     "DomainName": "{{this.DomainName}}",
-    {{#if this.DomainValidationOptions}}"DomainValidationOptions": [
-      { "DomainName": "{{this.DomainName}}", "ValidationDomain": "{{this.ValidationDomain}}"}
+    {{#if this.DomainValidationOptions}} "DomainValidationOptions": [
+      { {{#if this.ValidationDomain}}"ValidationDomain": "{{this.ValidationDomain}}",{{/if}}
+        "DomainName": "{{this.DomainName}}"
+
+        {{#with (lookupById @root.DNS (lowercase this.DomainName))}}
+          ,"HostedZoneId":"{{this.HostedZoneId}}"
+        {{/with}}
+
+      }
     ],{{/if}}
     {{#if this.SubjectAlternativeNames}}"SubjectAlternativeNames": [
       {{#each this.SubjectAlternativeNames}}"{{this}}"{{#unless @last}},{{/unless}}{{/each}}


### PR DESCRIPTION
This PR allows ACM certificate verification to happen if you use Route53 and DNS validation.