### PR TITLE
Add SSO partials

### DIFF
--- a/blueprints/common/base-all.hbs
+++ b/blueprints/common/base-all.hbs
@@ -642,6 +642,14 @@
     {{> ssm_parameter}},
     {{/each}}
 
+    {{#each SSOAssignments}}
+    {{> sso_assignment}},
+    {{/each}}
+
+    {{#each SSOPermissionSets}}
+    {{> sso_permissionset}},
+    {{/each}}
+
     {{#each SQSQueues}}
     {{> sqs_queue}},
     {{/each}}

--- a/blueprints/common/partials/sso_assignment.hbs
+++ b/blueprints/common/partials/sso_assignment.hbs
@@ -1,0 +1,23 @@
+{{!--
+  Assigns access to a Principal for a specified AWS account using a specified permission set.
+
+  https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sso-assignment.html
+ --}}
+"ssoassign{{sanitize this.Name ''}}": {
+  "Type": "AWS::SSO::Assignment",
+  "Properties": {
+    "InstanceArn": "{{this.InstanceArn}}",
+
+    "PermissionSetArn":
+      {{#startsWith 'arn:' this.PermissionSetArn}}
+        "{{this.PermissionSetArn}}",
+      {{else}}
+        { "Fn::GetAtt": ["ssopermset{{sanitize this.PermissionSetArn ''}}","PermissionSetArn"] },
+      {{/startsWith}}
+
+    "PrincipalId": "{{this.PrincipalId}}",
+    "PrincipalType": "{{this.PrincipalType}}",
+    "TargetId": "{{@root.Account.ID}}",
+    "TargetType": "AWS_ACCOUNT"
+  }
+}

--- a/blueprints/common/partials/sso_permissionset.hbs
+++ b/blueprints/common/partials/sso_permissionset.hbs
@@ -1,0 +1,20 @@
+{{!--
+  Specifies a permission set within a specified SSO instance.
+
+  https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sso-permissionset.html
+ --}}
+"ssopermset{{sanitize this.Name ''}}": {
+  "Type": "AWS::SSO::PermissionSet",
+  "Properties": {
+    "Name": "{{this.Name}}",
+    "InstanceArn": "{{this.InstanceArn}}",
+    {{#if this.Description}}"Description": "{{this.Description}}",{{/if}}
+    {{#if this.InlinePolicy}}"InlinePolicy": { {{{inject this.InlinePolicy}}} } ,{{/if}}
+    {{#if this.ManagedPolicies}}"ManagedPolicies": [
+      {{#each this.ManagedPolicies}}{{this}}{{comma}}{{/each}}
+    ],{{/if}}
+    {{#if this.RelayStateType}}"RelayStateType": "{{this.RelayStateType}}",{{/if}}
+    {{#if this.SessionDuration}}"SessionDuration": "{{this.SessionDuration}}",{{/if}}
+    {{> tags}}
+  }
+}


### PR DESCRIPTION
This PR adds a basic AWS SSO resources.  It's enough to define a permission set but not much else.  Unfortunately, that's about all that CFN offers for SSO management.  😦 