### PR TITLE
Update EC2 launch templates

### DIFF
--- a/blueprints/common/partials/autoscaling_group.hbs
+++ b/blueprints/common/partials/autoscaling_group.hbs
@@ -9,7 +9,17 @@
     "AutoScalingGroupName": "{{this.Name}}",
     {{#if this.Cooldown}}"Cooldown": "{{this.Cooldown}}",{{/if}}
     {{#if this.LaunchConfigurationName}}"LaunchConfigurationName":{ "Ref":"aslc{{sanitize this.LaunchConfigurationName ''}}" },{{/if}}
-    {{#if this.LaunchTemplate}}"LaunchTemplate":{ {{{inject this.LaunchTemplate}}} },{{/if}}
+    {{#if this.LaunchTemplate}}"LaunchTemplate": {
+      {{#with this.LaunchTemplate}}
+        {{#if this.LaunchTemplateId}}"LaunchTemplateId": { "Ref": "{{this.LaunchTemplateId}}" },{{/if}}
+        {{#if this.LaunchTemplateName}}"LaunchTemplateName": "{{this.LaunchTemplateName}}",{{/if}}
+        {{#if this.Version}}
+          "Version": "{{this.Version}}"
+        {{else}}
+          "Version": { "Fn::GetAtt": [ "ec2lt{{sanitize this.LaunchTemplateName ''}}", "LatestVersionNumber" ] }
+        {{/if}}
+      {{/with}}
+    },{{/if}}
     {{#if this.AvailabilityZones}}
       "AvailabilityZones": [{{#each this.AvailabilityZones}}"{{this}}"{{#unless @last}},{{/unless}}{{/each}}],
     {{/if}}
@@ -40,6 +50,7 @@
     {{#if this.MetricsCollection}}
       "MetricsCollection": [ {{#each this.MetricsCollection}}{ {{{inject this}}} }{{#unless @last}},{{/unless}}{{/each}} ],
     {{/if}}
+    {{#if this.MixedInstancesPolicy}}"MixedInstancesPolicy": { {{{inject this.MixedInstancesPolicy}}} },{{/if}}
     {{#if this.NotificationConfigurations}}{{#with this.NotificationConfigurations}}
       "NotificationConfigurations": [{{#each this}}
         { "NotificationTypes": [{{#each this.NotificationTypes}}"{{this}}"{{#unless @last}},{{/unless}}{{/each}}],
@@ -76,6 +87,5 @@
 
 {{!-- TODO
       "InstanceId" : String,
-      "MixedInstancesPolicy" : MixedInstancesPolicy,
       "PlacementGroup" : String,
  --}}

--- a/blueprints/common/partials/autoscaling_launchconfiguration.hbs
+++ b/blueprints/common/partials/autoscaling_launchconfiguration.hbs
@@ -1,5 +1,5 @@
 {{!--
- Creates a new Amazon Autoscaling Launch Configuration.
+ Creates a new Amazon Autoscaling Launch Configuration. [DEPRECATED]
 
   http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html
  --}}

--- a/blueprints/common/partials/ec2_launchtemplate.hbs
+++ b/blueprints/common/partials/ec2_launchtemplate.hbs
@@ -30,10 +30,11 @@
       {{#if this.InstanceInitiatedShutdownBehavior}}"InstanceInitiatedShutdownBehavior": "{{this.InstanceInitiatedShutdownBehavior}}",{{/if}}
       {{#if this.InstanceMarketOptions}}"InstanceMarketOptions": { {{{inject this.InstanceMarketOptions}}} },{{/if}}
       {{#if this.InstanceType}}"InstanceType": "{{this.InstanceType}}",{{/if}}
+      {{#if this.InstanceRequirements}}"InstanceRequirements": { {{{inject this.InstanceRequirements}}} },{{/if}}
       {{#if this.KernelId}}"KernelId": "{{this.KernelId}}",{{/if}}
       {{#if this.KeyName}}"KeyName": "{{this.KeyName}}",{{/if}}
       {{#if this.LicenseSpecifications}}"LicenseSpecifications": [ LicenseSpecification, ... ],{{/if}}
-      {{#if this.MetadataOptions}}"MetadataOptions": MetadataOptions,{{/if}}
+      {{#if this.MetadataOptions}}"MetadataOptions": { {{{inject this.MetadataOptions}}} },{{/if}}
       {{#if this.Monitoring}}"Monitoring": { {{{inject this.Monitoring}}} },{{/if}}
       {{#if this.NetworkInterfaces}}"NetworkInterfaces": [
         {{#each this.NetworkInterfaces}} {
@@ -76,13 +77,10 @@
         {{/ifObject}}
       {{else}}
         {{> (whichPartial "AMI" "user_data_" this) }}
-      {{/if}}
-{{!--
+      {{/if}},
       "TagSpecifications": [
-        { "ResourceType": "launch-template",
-        {{> tags}} }
+        { "ResourceType": "instance", {{> tags}} }
       ]
- --}}
     },
     "LaunchTemplateName": "{{this.Name}}"
   }

--- a/blueprints/common/partials/sso_permissionset.hbs
+++ b/blueprints/common/partials/sso_permissionset.hbs
@@ -6,7 +6,7 @@
 "ssopermset{{sanitize this.Name ''}}": {
   "Type": "AWS::SSO::PermissionSet",
   "Properties": {
-    "Name": "{{this.Name}}",
+    "Name": {{#if this.SetName}}"{{this.SetName}}"{{else}}"{{this.Name}}"{{/if}},
     "InstanceArn": "{{this.InstanceArn}}",
     {{#if this.Description}}"Description": "{{this.Description}}",{{/if}}
     {{#if this.InlinePolicy}}"InlinePolicy": { {{{inject this.InlinePolicy}}} } ,{{/if}}


### PR DESCRIPTION
This PR focuses on enhancing the EC2 launch templates.  This allows us to transition to IMDSv2 as well as opens the door for other options (ie. spot instances).