### PR TITLE
Small fixes

### DIFF
--- a/blueprints/common/partials/lambda_function.hbs
+++ b/blueprints/common/partials/lambda_function.hbs
@@ -38,6 +38,7 @@
       {{/startsWith}},
     {{/if}}
     {{#if this.Layers}}"Layers": [ {{{inject this.Layers}}} ],{{/if}}
+    {{#if this.LoggingConfig}}"LoggingConfig": { {{{inject this.LoggingConfig}}} },{{/if}}
     {{#if this.MemorySize}}"MemorySize":{{this.MemorySize}},{{/if}}
     {{#if this.PackageType}}"PackageType": "{{this.PackageType}}",{{/if}}
     {{#if this.ReservedConcurrentExecutions}}"ReservedConcurrentExecutions": {{this.ReservedConcurrentExecutions}},{{/if}}

--- a/blueprints/common/partials/wafv2_webacl.hbs
+++ b/blueprints/common/partials/wafv2_webacl.hbs
@@ -9,6 +9,7 @@
     "DefaultAction": { {{{inject this.DefaultAction}}} },
     {{#if this.Description}}"Description": "{{this.Description}}",{{/if}}
     "Name": "{{this.Name}}",
+    {{#if this.CustomResponseBodies}}"CustomResponseBodies": { {{{inject this.CustomResponseBodies}}} },{{/if}}
     {{#if this.Rules}}"Rules": [
       {{#each this.Rules}}{ {{{inject this}}} }{{#unless @last}},{{/unless}}{{/each}}
     ],{{/if}}


### PR DESCRIPTION
This pull request introduces enhancements to the `blueprints` templates by adding support for optional configuration properties in Lambda functions and WAFv2 WebACLs. These changes improve the flexibility and customization of generated templates.

### Enhancements to `blueprints` templates:

* **Lambda Function Template**:
  - Added support for an optional `LoggingConfig` property to allow specifying logging configurations for Lambda functions. (`blueprints/common/partials/lambda_function.hbs`, [blueprints/common/partials/lambda_function.hbsR41](diffhunk://#diff-1dad53a0480dc697119aede3dc1fff575e2efb51725bebd22e9b331993f4cec8R41))

* **WAFv2 WebACL Template**:
  - Added support for an optional `CustomResponseBodies` property to define custom response bodies for WAFv2 WebACLs. (`blueprints/common/partials/wafv2_webacl.hbs`, [blueprints/common/partials/wafv2_webacl.hbsR12](diffhunk://#diff-8e6b2a3a3297c6a58700b4500571462ca4a9ecd6fa4f007a07203b46a8961cf7R12))