### PR TITLE
Add/update Cognito blueprints

### DIFF
--- a/blueprints/common/base-all.hbs
+++ b/blueprints/common/base-all.hbs
@@ -70,6 +70,10 @@
     {{> apigateway_deployment}},
     {{/each}}
 
+    {{#each APIGatewayV2APIMappings}}
+    {{> apigatewayv2_apimapping}},
+    {{/each}}
+
     {{#each APIGatewayV2HttpAPIs}}
     {{> apigatewayv2_api}},
     {{/each}}
@@ -266,6 +270,14 @@
     {{> config_rule}},
     {{/each}}
 
+    {{#each CognitoIdentityPools}}
+    {{> cognito_identitypool}},
+    {{/each}}
+
+    {{#each CognitoManagedLoginBrandings}}
+    {{> cognito_managedloginbranding}},
+    {{/each}}
+
     {{#each CognitoUserPools}}
     {{> cognito_userpool}},
     {{/each}}
@@ -276,6 +288,10 @@
 
     {{#each CognitoUserPoolDomains}}
     {{> cognito_userpooldomain}},
+    {{/each}}
+
+    {{#each CognitoUserPoolIdentityProviders}}
+    {{> cognito_userpoolidentityprovider}},
     {{/each}}
 
     {{#each CognitoUserPoolRiskConfigurationAttachments}}

--- a/blueprints/common/partials/apigatewayv2_apimapping.hbs
+++ b/blueprints/common/partials/apigatewayv2_apimapping.hbs
@@ -1,0 +1,19 @@
+{{!--
+  The AWS::ApiGatewayV2::ApiMapping resource contains an API mapping.
+
+  https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-resource-apigatewayv2-apimapping.html
+ --}}
+
+"apiv2gwmap{{sanitize this.Name ''}}": {
+  "Type": "AWS::ApiGatewayV2::ApiMapping",
+  "Properties": {
+    "ApiId": {{#ifObject this.ApiId}}
+      { {{{inject this.ApiId}}} }
+    {{else}}
+      "{{this.ApiId}}"
+    {{/ifObject}},
+    {{#if this.ApiMappingKey}}"ApiMappingKey": "{{this.ApiMappingKey}}",{{/if}}
+    "DomainName": "{{this.DomainName}}",
+    "Stage": "{{this.Stage}}"
+  }
+}

--- a/blueprints/common/partials/apigatewayv2_route.hbs
+++ b/blueprints/common/partials/apigatewayv2_route.hbs
@@ -43,7 +43,7 @@
         "Target": {{#ifObject this.Target}}
           { {{{inject this.Target}}} }
         {{else}}
-          {{this.Target}}
+          "{{this.Target}}"
         {{/ifObject}},
       {{/if}}
 

--- a/blueprints/common/partials/cognito_identitypool.hbs
+++ b/blueprints/common/partials/cognito_identitypool.hbs
@@ -1,0 +1,24 @@
+{{!--
+  Creates an Amazon Cognito identity pool.
+
+  https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-resource-cognito-identitypool.html
+ --}}
+"cogip{{sanitize this.Name ''}}": {
+  "Type": "AWS::Cognito::IdentityPool",
+  "Properties": {
+    {{#if this.CognitoEvents}}"CognitoEvents": { {{{this.CognitoEvents}}} },{{/if}}
+    {{#if this.CognitoIdentityProviders}}"CognitoIdentityProviders": [
+      {{#each this.CognitoIdentityProviders}} { {{{inject this}}} }{{comma}}{{/each}}
+    ],{{/if}}
+    {{#if this.CognitoStreams}}"CognitoStreams": { {{{this.CognitoStreams}}} },{{/if}}
+    {{#if this.DeveloperProviderName}}"DeveloperProviderName": "{{this.DeveloperProviderName}}",{{/if}}
+    {{#if this.IdentityPoolTags}}"IdentityPoolTags": [ Tag, ... ],{{/if}}
+    {{#if this.OpenIdConnectProviderARNs}}"OpenIdConnectProviderARNs": [ "{{this.OpenIdConnectProviderARNs}}", ... ],{{/if}}
+    {{#if this.PushSync}}"PushSync": { {{{this.PushSync}}} },{{/if}}
+    {{#if this.SamlProviderARNs}}"SamlProviderARNs": [ "{{this.SamlProviderARNs}}", ... ],{{/if}}
+    {{#if this.SupportedLoginProviders}}"SupportedLoginProviders": { {{{this.SupportedLoginProviders}}} }{{/if}}
+    "AllowClassicFlow": {{default (toString this.AllowClassicFlow) false}},
+    "AllowUnauthenticatedIdentities": {{default (toString this.AllowUnauthenticatedIdentities) false}},
+    "IdentityPoolName": "{{this.Name}}"
+  }
+}

--- a/blueprints/common/partials/cognito_managedloginbranding.hbs
+++ b/blueprints/common/partials/cognito_managedloginbranding.hbs
@@ -1,0 +1,16 @@
+{{!--
+  Creates a new set of branding settings for a user pool style and associates it with an app client.
+
+  https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-resource-cognito-managedloginbranding.html
+ --}}
+"cogmlb{{sanitize this.Name ''}}": {
+  "Type": "AWS::Cognito::ManagedLoginBranding",
+  "Properties": {
+    {{#if this.Assets}}"Assets": [ {{#each this.Assets}}{ {{{inject this}}} }{{comma}}{{/each}} ],{{/if}}
+    {{#if this.ClientId}}"ClientId": "{{this.ClientId}}",{{/if}}
+    {{#if this.ReturnMergedResources}}"ReturnMergedResources":  {{default (toString this.ReturnMergedResources) false}},{{/if}}
+    {{#if this.Settings}}"Settings": { {{{inject this.Settings}}} },{{/if}}
+    {{#if this.UseCognitoProvidedValues}}"UseCognitoProvidedValues":  {{default (toString this.UseCognitoProvidedValues) false}},{{/if}}
+    "UserPoolId": {"Ref":"cogup{{sanitize this.UserPoolId ''}}"}
+  }
+}

--- a/blueprints/common/partials/cognito_userpoolclient.hbs
+++ b/blueprints/common/partials/cognito_userpoolclient.hbs
@@ -5,6 +5,9 @@
  --}}
 "cogupc{{sanitize this.Name ''}}": {
   "Type": "AWS::Cognito::UserPoolClient",
+  {{#if this.DependsOn}}
+    "DependsOn": [{{#each this.DependsOn}}"{{this}}"{{comma}}{{/each}}],
+  {{/if}}
   "Properties": {
     "ClientName": "{{this.Name}}",
     {{#if this.AllowedOAuthFlows}}"AllowedOAuthFlows":[

--- a/blueprints/common/partials/cognito_userpooldomain.hbs
+++ b/blueprints/common/partials/cognito_userpooldomain.hbs
@@ -7,6 +7,7 @@
   "Type": "AWS::Cognito::UserPoolDomain",
   "Properties": {
     {{#if this.CustomDomainConfig}}"CustomDomainConfig": { {{{inject this.CustomDomainConfig}}} },{{/if}}
+    {{#if this.ManagedLoginVersion}}"ManagedLoginVersion": {{this.ManagedLoginVersion}},{{/if}}
     "Domain": "{{this.Domain}}",
     "UserPoolId": { "Ref": "cogup{{sanitize this.UserPoolId ''}}" }
   }

--- a/blueprints/common/partials/cognito_userpoolidentityprovider.hbs
+++ b/blueprints/common/partials/cognito_userpoolidentityprovider.hbs
@@ -1,0 +1,16 @@
+{{!--
+  Creates an Amazon Cognito user pool identity provider (SAML, OIDC, etc.).
+
+  https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-resource-cognito-userpoolidentityprovider.html
+ --}}
+"cogupip{{sanitize this.Name ''}}": {
+  "Type": "AWS::Cognito::UserPoolIdentityProvider",
+  "Properties": {
+    {{#if this.AttributeMapping}}"AttributeMapping": { {{{inject this.AttributeMapping}}} },{{/if}}
+    {{#if this.IdpIdentifiers}}"IdpIdentifiers": [ {{#each this.IdpIdentifiers}}"{{this}}"{{comma}}{{/each}} ],{{/if}}
+    "ProviderDetails": { {{{inject this.ProviderDetails}}} },
+    "ProviderName": "{{this.Name}}",
+    "ProviderType": "{{this.ProviderType}}",
+    "UserPoolId": {"Ref":"cogup{{sanitize this.UserPoolId ''}}"}
+  }
+}

--- a/blueprints/common/partials/logs_loggroup.hbs
+++ b/blueprints/common/partials/logs_loggroup.hbs
@@ -7,7 +7,11 @@
 "loggrp{{sanitize this.Name ''}}": {
   "Type": "AWS::Logs::LogGroup",
   "Properties": {
-    "LogGroupName": "{{this.Name}}",
+    "LogGroupName": {{#ifObject this.Name}}
+        { {{{inject this.Name}}} }
+      {{else}}
+        "{{this.Name}}"
+      {{/ifObject}},
     "RetentionInDays": {{this.RetentionInDays}}
   }
 }


### PR DESCRIPTION
This pull request adds support for several new AWS resources to the blueprint templates, particularly for Cognito and API Gateway V2, and improves the handling of some existing resources. The main changes include new partial templates for Cognito identity pools, managed login branding, and user pool identity providers, as well as updates to the main blueprint to render these resources. Additionally, there are improvements to how object references are injected in several existing templates.

**New AWS Resource Support**

* Added a new partial template `apigatewayv2_apimapping.hbs` and updated `base-all.hbs` to support rendering API Gateway V2 API mappings. [[1]](diffhunk://#diff-62642c9ea96fa57c2ce5de16188d10ea501e8307e2401b3124d4daff763fffa6R1-R19) [[2]](diffhunk://#diff-0655b474d944b03a62d5562c60782b2222b910fbe1fc84e3407c0ec5dd9020a2R73-R76)
* Added new partial templates for Cognito resources: `cognito_identitypool.hbs`, `cognito_managedloginbranding.hbs`, and `cognito_userpoolidentityprovider.hbs`, with corresponding updates to `base-all.hbs` to render these resources. [[1]](diffhunk://#diff-17dda4c1362bde9ee2e6490386cfcc3b5dc0d8713357b68a55e8a53396cf17d5R1-R24) [[2]](diffhunk://#diff-41f7b9192976d4b7efc4b38bc9a6d3051ca63aeb803cebd2ccf87a442537e989R1-R16) [[3]](diffhunk://#diff-3d7c1aee28f2ba189b7f6ba9db3941d1921bc77257e55699261a5cb5fee44b73R1-R16) [[4]](diffhunk://#diff-0655b474d944b03a62d5562c60782b2222b910fbe1fc84e3407c0ec5dd9020a2R273-R280) [[5]](diffhunk://#diff-0655b474d944b03a62d5562c60782b2222b910fbe1fc84e3407c0ec5dd9020a2R293-R296)

**Enhancements to Existing Resources**

* Updated `cognito_userpooldomain.hbs` to support the `ManagedLoginVersion` property.
* Improved `cognito_userpoolclient.hbs` to support a `DependsOn` property for better resource dependency management.

**Object Reference Handling Improvements**

* Improved the handling of object references in `apigatewayv2_route.hbs` and `logs_loggroup.hbs` to ensure correct injection and quoting of values. [[1]](diffhunk://#diff-ece50c094d853bac1e78f6d12ede7bbcfb611a7e1595f5e28fbed3d5de784f1aL46-R46) [[2]](diffhunk://#diff-fbb188d3e01ceb567a686b43b698bebf112c5f8629a52e72488c628d2edd86bcL10-R14)