### PR TITLE
Add ChatBot blueprints

### DIFF
--- a/blueprints/common/base-all.hbs
+++ b/blueprints/common/base-all.hbs
@@ -182,6 +182,10 @@
     {{> ce_anomalysubscription}},
     {{/each}}
 
+    {{#each ChatBotMSTeamsChannels}}
+    {{> chatbot_microsoftteamschannelconfiguration}},
+    {{/each}}
+
     {{#each CloudFormationMacros}}
     {{> cloudformation_macro}},
     {{/each}}
@@ -796,6 +800,10 @@
 
     {{#each SSOPermissionSets}}
     {{> sso_permissionset}},
+    {{/each}}
+
+    {{#each StepFunctionsStateMachines}}
+    {{> stepfunctions_statemachine}},
     {{/each}}
 
     {{#each SQSQueues}}

--- a/blueprints/common/partials/chatbot_microsoftteamschannelconfiguration.hbs
+++ b/blueprints/common/partials/chatbot_microsoftteamschannelconfiguration.hbs
@@ -1,0 +1,33 @@
+{{!--
+  The AWS::Chatbot::MicrosoftTeamsChannelConfiguration resource configures a Microsoft
+  Teams channel to allow users to use Amazon Q Developer with AWS CloudFormation templates.
+
+  https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-resource-chatbot-microsoftteamschannelconfiguration.html
+ --}}
+"chatmsteamschnl{{sanitize this.Name ''}}" : {
+  "Type": "AWS::Chatbot::MicrosoftTeamsChannelConfiguration",
+  "Properties": {
+    "ConfigurationName": "{{this.Name}}",
+    "IamRoleArn": {"Fn::GetAtt" : ["iamr{{sanitize this.IamRoleArn ''}}", "Arn"] },
+    "TeamId": "{{this.TeamId}}",
+    "TeamsChannelId": "{{this.TeamsChannelId}}",
+    "TeamsTenantId": "{{this.TeamsTenantId}}",
+    {{#if this.CustomizationResourceArns}}"CustomizationResourceArns": [
+      {{#each this.CustomizationResourceArns}}"{{this}}"{{/each}}{{comma}}
+    ],{{/if}}
+    {{#if this.GuardrailPolicies}}"GuardrailPolicies": [
+      {{#each this.GuardrailPolicies}}"{{this}}"{{comma}}{{/each}}
+    ],{{/if}}
+    {{#if this.LoggingLevel}}"LoggingLevel": "{{this.LoggingLevel}}",{{/if}}
+    {{#if this.SnsTopicArns}}"SnsTopicArns": [
+      {{#each this.SnsTopicArns}}"{{this}}"{{comma}}{{/each}}
+    ],{{/if}}
+    {{#if this.TeamsChannelName}}
+      "TeamsChannelName": "{{this.TeamsChannelName}}",
+    {{else}}
+      "TeamsChannelName": "{{this.Name}}",
+    {{/if}}
+    {{#if this.UserRoleRequired}}"UserRoleRequired": Boolean,{{/if}}
+    {{> tags}}
+  }
+}

--- a/blueprints/common/partials/events_rule.hbs
+++ b/blueprints/common/partials/events_rule.hbs
@@ -8,11 +8,11 @@
   "Type":"AWS::Events::Rule",
   "Properties":{
     {{#if this.EventPattern}}"EventPattern":{ {{{inject this.EventPattern}}} },{{/if}}
-    {{#if this.Role}}
-    "RoleArn":{{#startsWith "arn:aws:" this.Role}}
-      "{{this.Role}}"
+    {{#if this.RoleArn}}
+    "RoleArn":{{#startsWith "arn:aws:" this.RoleArn}}
+      "{{this.RoleArn}}"
     {{else}}
-      { "Fn::GetAtt":[ "iamr{{this.Role}}", "Arn"] }
+      { "Fn::GetAtt":[ "iamr{{this.RoleArn}}", "Arn"] }
     {{/startsWith}},
     {{/if}}
     {{#if this.ScheduleExpression}}"ScheduleExpression":"{{this.ScheduleExpression}}",{{/if}}
@@ -20,6 +20,12 @@
     {{#if this.Targets}}"Targets":[{{#each this.Targets}}
       { {{#if this.Input}}"Input":"{ {{{inject this.Input true}}} }",{{/if}}
         {{#if this.InputPath}}"InputPath":"{{this.InputPath}}",{{/if}}
+        {{#if this.InputTransformer}}"InputTransformer": {
+
+          "InputPathsMap": { {{{inject this.InputTransformer.InputPathsMap}}} },
+          "InputTemplate": "{ {{{inject this.InputTransformer.InputTemplate true}}} }"
+
+        },{{/if}}
         "Arn":{{#startsWith "arn:aws:" this.Arn}}
         "{{this.Arn}}"
         {{else}}
@@ -32,9 +38,11 @@
             { "Fn::GetAtt":[ "iamr{{this.RoleArn}}", "Arn"] }
           {{/startsWith}},
         {{/if}}
+
         "Id":"{{this.Id}}"
-      }{{#unless @last}},{{/unless}}{{/each}}],{{/if}}
+      }{{comma}}{{/each}}],{{/if}}
     {{#if this.Description}}"Description":"{{this.Description}} ({{@root.ProjectName}}-{{@root.EnvVersion}}{{@root.EnvName}})",{{/if}}
-    "Name":"{{this.Name}}"
+    "Name":"{{this.Name}}",
+    {{> tags}}
   }
 }

--- a/blueprints/common/partials/lambda_function.hbs
+++ b/blueprints/common/partials/lambda_function.hbs
@@ -42,6 +42,7 @@
     {{#if this.MemorySize}}"MemorySize":{{this.MemorySize}},{{/if}}
     {{#if this.PackageType}}"PackageType": "{{this.PackageType}}",{{/if}}
     {{#if this.ReservedConcurrentExecutions}}"ReservedConcurrentExecutions": {{this.ReservedConcurrentExecutions}},{{/if}}
+    {{#if this.Runtime}}"Runtime":"{{this.Runtime}}",{{/if}}
     {{#if this.Timeout}}"Timeout":{{this.Timeout}},{{/if}}
     {{#if this.TracingConfig}}"TracingConfig": { {{{inject this.TracingConfig}}} },{{/if}}
     {{#if this.VpcConfig}}"VpcConfig":{
@@ -63,7 +64,6 @@
       },
     {{/if}}
     "Role":{ "Fn::GetAtt":[ "iamr{{this.Role}}","Arn"] },
-    "Runtime":"{{this.Runtime}}",
     "FunctionName":"{{this.Name}}",
     {{> tags Role=''}}
   }

--- a/blueprints/common/partials/sns_subscription.hbs
+++ b/blueprints/common/partials/sns_subscription.hbs
@@ -9,9 +9,18 @@
     {{#if this.Endpoint}}"Endpoint": "{{this.Endpoint}}",{{/if}}
     {{#if this.DeliveryPolicy}}"DeliveryPolicy": { {{{inject this.DeliveryPolicy}}} },{{/if}}
     {{#if this.FilterPolicy}}"FilterPolicy": { {{{inject this.FilterPolicy}}} },{{/if}}
+    {{#if this.FilterPolicyScope}}"FilterPolicyScope": "{{this.FilterPolicyScope}}",{{/if}}
     {{#if (toString this.RawMessageDelivery)}}"RawMessageDelivery": {{toString this.RawMessageDelievery}},{{/if}}
     {{#if this.RedrivePolicy}}"RedrivePolicy": { {{{inject this.RedrivePolicy}}} },{{/if}}
+    {{#if this.ReplayPolicy}}"ReplayPolicy": { {{{inject this.ReplayPolicy}}} },{{/if}}
     {{#if this.Region}}"Region": "{{this.Region}}",{{/if}}
+    {{#if this.SubscriptionRoleArn}}
+      "SubscriptionRoleArn": {{#startsWith "arn:aws:" this.SubscriptionRoleArn}}
+          "{{this.SubscriptionRoleArn}}"
+        {{else}}
+          { "Ref": "iamr{{sanitize this.SubscriptionRoleArn ''}}" }
+      {{/startsWith}},
+    {{/if}}
     "Protocol": "{{this.Protocol}}",
     "TopicArn": {{#startsWith "arn:aws:" this.TopicArn}}"{{this.TopicArn}}"{{else}}
       { "Ref": "snst{{sanitize this.TopicArn ''}}" }

--- a/blueprints/common/partials/tags.hbs
+++ b/blueprints/common/partials/tags.hbs
@@ -7,8 +7,11 @@
   {{#if @root.EnvName}}{ "Key": "Environment", "Value": "{{@root.EnvName}}" },{{/if}}
   {{#if @root.EnvVersion}}{ "Key": "Version", "Value": "{{@root.EnvVersion}}" },{{/if}}
   {{#if @root.ProjectName}}{ "Key": "Project", "Value": "{{@root.ProjectName}}" },{{/if}}
-  {{#if @root.Role}}{ "Key": "Role",  "Value": "{{@root.Role}}" },{{/if}}
-  {{#if this.Role}}{ "Key": "Role",  "Value": "{{this.Role}}" },{{/if}}
+  {{#if @root.Role}}
+    { "Key": "Role",  "Value": "{{@root.Role}}" },
+  {{else}}
+    {{#if this.Role}}{ "Key": "Role",  "Value": "{{this.Role}}" },{{/if}}
+  {{/if}}
   {{#if @root.Owner}}{ "Key": "Owner", "Value": "{{@root.Owner}}" },{{/if}}
   { "Key": "Name","Value": "{{this.Name}}" }
 ]


### PR DESCRIPTION
This pull request expands AWS CloudFormation template support for new resource types and improves flexibility and correctness in several existing partials. The most significant updates include adding Microsoft Teams channel configuration support for AWS Chatbot, enhancing EventBridge rule and SNS subscription partials, and improving tag rendering logic.

New AWS resource support:

* Added support for `AWS::Chatbot::MicrosoftTeamsChannelConfiguration` by introducing the `chatbot_microsoftteamschannelconfiguration.hbs` partial and updating `base-all.hbs` to render these resources. [[1]](diffhunk://#diff-746f9ae5ba2309082b018ff6e11035c7028e02ea960e1d5604727f14f35a2257R1-R33) [[2]](diffhunk://#diff-0655b474d944b03a62d5562c60782b2222b910fbe1fc84e3407c0ec5dd9020a2R185-R188)

Enhancements to EventBridge rule configuration:

* Improved `events_rule.hbs` to support `InputTransformer` for targets, switched from `Role` to `RoleArn` for clarity, and added tag rendering to the resource properties. [[1]](diffhunk://#diff-4681d71d6d5ad702ca321375d6181176b53f49fa8ec3247cceca3b98505f77fbL11-R28) [[2]](diffhunk://#diff-4681d71d6d5ad702ca321375d6181176b53f49fa8ec3247cceca3b98505f77fbR41-R46)

Enhancements to SNS subscription configuration:

* Added support for `FilterPolicyScope`, `ReplayPolicy`, and `SubscriptionRoleArn` in `sns_subscription.hbs`, increasing flexibility for SNS subscriptions.

Improvements to Lambda function partials:

* Adjusted `lambda_function.hbs` to render `Runtime` only when specified, preventing duplicate or missing runtime properties. [[1]](diffhunk://#diff-1dad53a0480dc697119aede3dc1fff575e2efb51725bebd22e9b331993f4cec8R45) [[2]](diffhunk://#diff-1dad53a0480dc697119aede3dc1fff575e2efb51725bebd22e9b331993f4cec8L66)

Tag rendering logic improvements:

* Updated `tags.hbs` to prefer `@root.Role` if present, otherwise fall back to `this.Role`, ensuring correct tag assignment across resources.