### PR TITLE
Resolve race condition

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -58,14 +58,15 @@ function regionizeContext(context, region) {
 }
 
 // Read a file from disk, extract the data, and process it against it's context
-function readAndProcessTemplate(filename, context) {
+function readAndProcessTemplate(filename, context, blueprintsDir) {
   // We want to make sure the end-user can override pre-provided blueprints.  So we'll use
   // the 'global' version of the file unless there is a local version of that file.
   var filelocation = __dirname + '/../blueprints/' + filename;
   try {
     // Look for a local version of the file and use that instead
-    fs.statSync(filename);
-    filelocation = filename;
+    var localPath = blueprintsDir + '/' + filename;
+    fs.statSync(localPath);
+    filelocation = localPath;
   } catch(err){
     // We didn't find a local version of the file
   }
@@ -78,6 +79,7 @@ function readAndProcessTemplate(filename, context) {
 function build(cwd, template, cb) {
   try {
     var GLOBALS = JSON.parse(processTemplate(fs.readFileSync(cwd + '/blueprints/common/globals.hbs')));
+    GLOBALS.__blueprintsDir__ = cwd + '/blueprints';
   } catch(err) {
     console.log("Can't find your 'globals.hbs' file.  Please create one and try again.\n%s", err);
     return;
@@ -85,10 +87,10 @@ function build(cwd, template, cb) {
 
   // Make sure the directory structure is properly configured for output
   fs.mkdirsSync(cwd + '/artifacts/cloudformation');
-  process.chdir(cwd + '/blueprints');
+  var blueprintsDir = cwd + '/blueprints';
 
   // Look for files to process
-  fs.readdir('stacks', function(err, files) {
+  fs.readdir(blueprintsDir + '/stacks', function(err, files) {
     if (err) {
       cb(err);
       return;
@@ -111,9 +113,9 @@ function build(cwd, template, cb) {
       var projectName = pathArray[0];
       var env = pathArray[1];
       var ENVIRON = JSON.parse(processTemplate(fs.readFileSync(cwd + '/blueprints/common/'+env+'.hbs'), GLOBALS));
-      var globalContext = merge(GLOBALS, ENVIRON);
+      var globalContext = merge(merge({}, GLOBALS), ENVIRON);
 
-      GLOBALS.Regions.forEach(function(region) {
+      globalContext.Regions.forEach(function(region) {
         try {
           var projectContext = regionizeContext(globalContext, region);
           // The "ProjectName" variable is a special case.  It lives in the template and
@@ -122,8 +124,8 @@ function build(cwd, template, cb) {
           // can't self-reference.  Therefor, we set the "ProjectName" to a temp value,
           // process the template, and then set it to the value from the template.
           projectContext.ProjectName = 'ZZZZ';
-          projectContext.ProjectName = helpfulJsonParse(readAndProcessTemplate('stacks/'+filename, projectContext)).ProjectName;
-          var projectTemplate = readAndProcessTemplate('stacks/'+filename, projectContext);
+          projectContext.ProjectName = helpfulJsonParse(readAndProcessTemplate('stacks/'+filename, projectContext, blueprintsDir)).ProjectName;
+          var projectTemplate = readAndProcessTemplate('stacks/'+filename, projectContext, blueprintsDir);
           var project = helpfulJsonParse(projectTemplate);
 
           // Only process templates with no region specified or one that matches the current region
@@ -135,7 +137,7 @@ function build(cwd, template, cb) {
           // Build the final template
           console.log('Processing %s:%s', region.Id, filename);
           var master = merge(project, projectContext);
-          var template = readAndProcessTemplate(project.Template, master);
+          var template = readAndProcessTemplate(project.Template, master, blueprintsDir);
 
           // Make the template pretty and human readable, if the length isn't too long
           // console.log(template.length)

--- a/lib/process-template.js
+++ b/lib/process-template.js
@@ -200,7 +200,9 @@ var helpers = {
    *   },
    */
   include: function (file, context) {
-    var f = fs.readFileSync(file);
+    var blueprintsDir = context && context.data && context.data.root && context.data.root.__blueprintsDir__;
+    var resolvedFile = blueprintsDir ? path.resolve(blueprintsDir, file) : file;
+    var f = fs.readFileSync(resolvedFile);
     return processTemplate(f, context);
   },
 
@@ -219,7 +221,9 @@ var helpers = {
    *   },
    */
   includeAsString: function (file, context) {
-    var f = fs.readFileSync(file);
+    var blueprintsDir = context && context.data && context.data.root && context.data.root.__blueprintsDir__;
+    var resolvedFile = blueprintsDir ? path.resolve(blueprintsDir, file) : file;
+    var f = fs.readFileSync(resolvedFile);
     return JSON.stringify(processTemplate(f, context));
   },
 


### PR DESCRIPTION
This pull request updates the template processing logic to better support customizable blueprint directories and improve context handling. The main improvements include allowing the use of a configurable blueprints directory, ensuring context objects are not mutated, and making file inclusion helpers aware of the blueprint directory for correct file resolution.

**Template processing and blueprint directory handling:**

* The `readAndProcessTemplate` function now accepts a `blueprintsDir` parameter, and prioritizes loading files from this directory if present, allowing users to override global blueprints with local versions.
* The `build` function sets and passes the blueprint directory (`blueprintsDir`) throughout the template processing flow, ensuring all file reads are correctly scoped to the intended directory. [[1]](diffhunk://#diff-1ae50dc56d6f821fbc0183fc424426e7cf420c9f5e0a0a5fd0e1801a573b8fd0R82-R93) [[2]](diffhunk://#diff-1ae50dc56d6f821fbc0183fc424426e7cf420c9f5e0a0a5fd0e1801a573b8fd0L125-R128) [[3]](diffhunk://#diff-1ae50dc56d6f821fbc0183fc424426e7cf420c9f5e0a0a5fd0e1801a573b8fd0L138-R140)
* The context's `GLOBALS` object is now cloned before merging with environment-specific variables, preventing unintended mutations to the global context.

**Template helper improvements:**

* The `include` and `includeAsString` helpers in `process-template.js` now resolve file paths relative to the blueprint directory if provided in the context, ensuring included files are loaded from the correct location. [[1]](diffhunk://#diff-7afe3010e7ec56303a450805f37351149d6453adbcc9f479f2c7365920c4105eL203-R205) [[2]](diffhunk://#diff-7afe3010e7ec56303a450805f37351149d6453adbcc9f479f2c7365920c4105eL222-R226)