### PR TITLE
Update string processing

### DIFF
--- a/blueprints/common/partials/ssm_parameter.hbs
+++ b/blueprints/common/partials/ssm_parameter.hbs
@@ -6,7 +6,7 @@
 "ssmp{{sanitize this.Name ''}}":{
   "Type": "AWS::SSM::Parameter",
   "Properties": {
-    "Name": "{{this.Name}}",
+    "Name": {{#ifObject this.Name}}{ {{{inject this.Name}}} }{{else}}"{{this.Name}}"{{/ifObject}},
     {{#if this.AllowedPattern}}"AllowedPattern": "{{this.AllowedPattern}}",{{/if}}
     {{#if this.Description}}"Description": "{{this.Description}}",{{/if}}
     {{#if this.Policies}}"Policies": "{{this.Policies}}",{{/if}}

--- a/lib/process-template.js
+++ b/lib/process-template.js
@@ -29,6 +29,19 @@ function registerPartials(filepath) {
 // things like if/then/else logic, sting manipulation, counting, etc.
 swag.registerHelpers(hbs);
 
+// Unwrap a CloudFormation `Fn::Sub` intrinsic to its literal template string
+// so swag's string helpers can operate on it. Accepts both forms:
+//   { "Fn::Sub": "foo-${BAR}" }                       -> "foo-${BAR}"
+//   { "Fn::Sub": ["foo-${BAR}", { BAR: "x" }] }       -> "foo-${BAR}"
+// Anything else is returned unchanged.
+function unwrapCfn(value) {
+  if (value && typeof value === 'object' && 'Fn::Sub' in value) {
+    var sub = value['Fn::Sub'];
+    return Array.isArray(sub) ? sub[0] : sub;
+  }
+  return value;
+}
+
 // Define our custom helpers
 var helpers = {
   /**
@@ -319,6 +332,46 @@ var helpers = {
    */
   raw: function (options) {
     return options.fn(this);
+  },
+
+
+  /**
+   * {{sanitize}}, {{lowercase}}, {{uppercase}}
+   *
+   * Override swag's string helpers so they also accept a CloudFormation
+   * `Fn::Sub` intrinsic. Plain strings behave exactly like swag's helpers;
+   * `{ "Fn::Sub": "..." }` (or the array form) is unwrapped to its literal
+   * template string first. For `sanitize`, that means `${VAR}` placeholders
+   * are stripped along with every other non-alphanumeric character.
+   *
+   * @example
+   *   {{sanitize this.Name ''}}
+   *   // "123-${BLAH}-test"             -> "123BLAHtest"
+   *   // {"Fn::Sub": "123-${BLAH}-test"} -> "123BLAHtest"
+   *
+   *   {{lowercase this.Name}}
+   *   // {"Fn::Sub": "FOO-${BAR}"}       -> "foo-${bar}"
+   */
+  sanitize: function (str, replaceWith) {
+    var replacement = typeof replaceWith === 'string' ? replaceWith : '-';
+    return String(unwrapCfn(str)).replace(/[^a-z0-9]/gi, replacement);
+  },
+
+  lowercase: function (str) {
+    return String(unwrapCfn(str)).toLowerCase();
+  },
+
+  uppercase: function (str) {
+    return String(unwrapCfn(str)).toUpperCase();
+  },
+
+  truncate: function (str, length, omission) {
+    var suffix = typeof omission === 'string' ? omission : '';
+    var value = String(unwrapCfn(str));
+    if (value.length > length) {
+      return value.substring(0, length - suffix.length) + suffix;
+    }
+    return value;
   },
 
 


### PR DESCRIPTION
This pull request improves how CloudFormation `Fn::Sub` intrinsic functions are handled in template processing and enhances the robustness of string helper functions. The main focus is on ensuring that string helpers such as `sanitize`, `lowercase`, and `uppercase` can correctly process both plain strings and `Fn::Sub` objects, leading to more flexible and reliable template generation.

**Enhancements to CloudFormation intrinsic and string helper handling:**

* Added the `unwrapCfn` utility function to extract the literal template string from a CloudFormation `Fn::Sub` intrinsic, supporting both string and array forms.
* Overrode the `sanitize`, `lowercase`, and `uppercase` helpers to automatically unwrap `Fn::Sub` objects before performing their string operations, ensuring consistent behavior regardless of input type.
* Updated the `truncate` helper to also handle unwrapped `Fn::Sub` values, improving its reliability with dynamic CloudFormation content.

**Template rendering improvements:**

* Modified the `ssm_parameter.hbs` partial so that the `Name` property can now correctly handle both plain strings and injected objects, improving compatibility with dynamic CloudFormation parameters.